### PR TITLE
Add Docker packaging with a graphical web interface for Polymer

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,49 @@
+# Verifica che l'immagine Docker di Polymer si costruisca correttamente.
+# NON pubblica alcuna immagine: la licenza di Polymer vieta la ridistribuzione.
+name: docker-build
+
+on:
+  push:
+    paths:
+      - "docker/**"
+      - "environment.yml"
+      - "polymer/**"
+      - "meson.build"
+      - "makefile"
+      - ".github/workflows/docker-build.yml"
+  pull_request:
+    paths:
+      - "docker/**"
+      - "environment.yml"
+      - "polymer/**"
+      - "meson.build"
+      - "makefile"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: polymer-gui:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke test — moduli compilati e job runner importabile
+        run: |
+          docker run --rm polymer-gui:ci \
+            micromamba run -n polymer python -c "import polymer.polymer_main, polymer.water; print('Cython OK')"
+          docker run --rm --entrypoint bash polymer-gui:ci -lc \
+            "micromamba run -n polymer python -c 'import ast; ast.parse(open(\"/app/polymer_job.py\").read()); ast.parse(open(\"/app/streamlit_app.py\").read()); print(\"app OK\")'"

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Docker packaging: user data (input products, results, downloaded auxdata, credentials)
+/data/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ http://www.opticsinfobase.org/oe/abstract.cfm?uri=oe-19-10-9783
 
 ## 1. Installation
 
+### 1.0 Docker container with a graphical interface (easiest)
+
+If you just want to *run* Polymer without setting up a Python environment or
+compiling anything, use the Docker packaging in [`docker/`](docker/): install
+Docker Desktop, double-click a launcher script, and drive Polymer from a web page
+in your browser. See [`docker/README_DOCKER.md`](docker/README_DOCKER.md).
+
+Note: the resulting image must **not** be redistributed (see `LICENCE.TXT`); every
+user builds it locally from this repository.
+
 ### 1.1 Python environment
 
 Polymer is written in python. It requires the installation of a python environment with the

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+# check=skip=FromPlatformFlagConstDisallowed
+# Polymer + interfaccia grafica web, in un unico container.
+#
+# NOTA LICENZA: questa immagine NON deve essere ridistribuita (LICENCE.TXT, Sez. 2).
+# Ogni utente la costruisce in locale a partire da questo repository.
+#
+# Build (dalla radice del repository):
+#   docker compose -f docker/docker-compose.yml build
+#
+# L'ambiente Python e' ricreato dal lock conda-forge del repo (environment.yml).
+# I moduli Cython di Polymer vengono compilati qui.  I dati ausiliari statici NON
+# sono inclusi: si scaricano al primo avvio dentro un volume montato.
+
+# environment.yml e' un lock conda per linux-64: l'immagine e' quindi solo amd64.
+# Su Mac Apple Silicon viene eseguita in emulazione (piu' lenta, ma funziona).
+FROM --platform=linux/amd64 mambaorg/micromamba:1.5-jammy
+
+# --- pacchetti di sistema (git serve per le dipendenze pip da GitHub) ---
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git ca-certificates curl tini make build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- ambiente conda "polymer" dal lock del repo ---
+COPY environment.yml /tmp/environment.yml
+# L'ambiente e' scelto con -n (la riga "name:" vuota del file viene ignorata).
+RUN micromamba create -y -n polymer -f /tmp/environment.yml \
+    && micromamba run -n polymer pip install --no-cache-dir "streamlit>=1.36" \
+    && micromamba clean -y --all
+
+ENV MAMBA_DEFAULT_ENV=polymer \
+    ENV_NAME=polymer \
+    PATH=/opt/conda/envs/polymer/bin:$PATH \
+    PYTHONPATH=/opt/polymer \
+    PYTHONUNBUFFERED=1
+
+# I dati (input/output/auxdata/ancillary/config) vivono qui, su volumi montati.
+# Le variabili e le cartelle devono esistere gia' in fase di build: importando
+# polymer, params.py risolve queste directory tramite core.env.getdir, che SOLLEVA
+# un'eccezione se la cartella non esiste.  DIR_DATA e' il fallback comune e va
+# impostato anche lui (viene valutato sempre, pure quando le altre var sono definite).
+ENV DIR_DATA=/data \
+    DIR_POLYMER_AUXDATA=/data/auxdata/static \
+    DIR_POLYMER_ANCILLARY=/data/ancillary \
+    HOME=/data/config \
+    OMP_NUM_THREADS=1
+RUN mkdir -p /data/input /data/output /data/auxdata/static /data/ancillary /data/config
+
+# --- sorgente di Polymer + compilazione dei moduli Cython ---
+WORKDIR /opt/polymer
+COPY polymer/     ./polymer/
+COPY meson.build makefile pyproject.toml ./
+COPY tools/       ./tools/
+RUN micromamba run -n polymer make \
+    && micromamba run -n polymer python -c "import polymer.polymer_main, polymer.water, polymer.clut, polymer.neldermead, polymer.polymer_minimizer; print('moduli Cython OK')"
+
+# --- interfaccia grafica + licenza (mostrata nell'app) ---
+COPY docker/app/  /app/
+COPY LICENCE.TXT  /app/LICENCE.TXT
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+EXPOSE 8501
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/docker/Dockerfile.dockerignore
+++ b/docker/Dockerfile.dockerignore
@@ -1,0 +1,20 @@
+# Contesto di build minimale: servono solo sorgente Polymer, environment.yml,
+# la cartella docker/ e la licenza.
+data/
+tests/
+docs/
+build/
+.git/
+.github/
+.claude/
+*.so
+*.png
+*.nc
+*.hdf
+__pycache__/
+*.pyc
+.pixi/
+pixi.lock
+README_v5.md
+CHANGELOG.TXT
+example.py

--- a/docker/README_DOCKER.md
+++ b/docker/README_DOCKER.md
@@ -1,0 +1,109 @@
+# Polymer in Docker, con interfaccia grafica
+
+Questa cartella contiene tutto il necessario per usare **Polymer** senza installare
+Python, senza compilare nulla e senza usare la riga di comando. I parametri si
+impostano da una pagina web che si apre nel browser.
+
+> **Licenza.** Polymer è di HYGEOS e **non può essere ridistribuito** (vedi
+> `LICENCE.TXT`, Sezione 2). Per questo qui trovi solo le *istruzioni di
+> costruzione*: l'immagine Docker viene creata sul tuo computer, in locale.
+> Al primo avvio dovrai accettare i Termini d'uso di Polymer.
+
+---
+
+## 1. Installa Docker Desktop (una volta sola)
+
+| Sistema | Link |
+|---|---|
+| Windows 10/11 | <https://desktop.docker.com/win/main/amd64/Docker%20Desktop%20Installer.exe> |
+| macOS (Apple Silicon: M1/M2/M3/M4) | <https://desktop.docker.com/mac/main/arm64/Docker.dmg> |
+| macOS (Intel) | <https://desktop.docker.com/mac/main/amd64/Docker.dmg> |
+| Linux | <https://docs.docker.com/desktop/install/linux/> |
+
+Installa, avvia **Docker Desktop** e aspetta che l'icona della balena sia stabile
+(stato "running").
+
+## 2. Scarica questo repository
+
+- Pulsante verde **Code → Download ZIP** su GitHub, poi estrai la cartella;
+- oppure, se hai git: `git clone <url-del-repository>`.
+
+## 3. Avvia Polymer
+
+Apri la cartella `docker/launchers/` e fai **doppio clic** su:
+
+- **Windows** → `Avvia-Polymer-Windows.bat`
+- **macOS / Linux** → `Avvia-Polymer-macOS-Linux.command`
+  (su macOS la prima volta: tasto destro → **Apri** per superare il blocco Gatekeeper)
+
+La **prima volta** la costruzione richiede **10–20 minuti** (scarica ~4 GB di
+librerie scientifiche e compila i moduli di calcolo). Le volte successive l'avvio è
+quasi immediato.
+
+Quando è pronto, il browser si apre da solo su **<http://localhost:8501>**.
+
+> In alternativa, da un terminale nella cartella del repository:
+> ```bash
+> docker compose -f docker/docker-compose.yml up --build
+> ```
+
+## 4. Prima configurazione (nell'interfaccia)
+
+1. **Accetta i Termini d'uso** di Polymer.
+2. Scheda **Configurazione → Scarica dati ausiliari** (circa 1 GB, una volta sola).
+3. *(Facoltativo)* Scheda **Configurazione → Credenziali dati meteo**: inserisci
+   l'utente/password di [NASA Earthdata](https://urs.earthdata.nasa.gov/users/new)
+   oppure la [CDS API key](https://cds.climate.copernicus.eu/user/register).
+   Senza credenziali, Polymer usa comunque delle climatologie interne.
+
+## 5. Elabora un prodotto
+
+1. Copia i tuoi prodotti **Level-1** nella cartella `data/input/` che è comparsa
+   accanto al repository (cartelle `.SEN3` per Sentinel-3 OLCI, `.SAFE` per
+   Sentinel-2 MSI, file `.he5` per PRISMA, `.N1` per MERIS, `.L1C` per MODIS/VIIRS/SeaWiFS…).
+2. Nella scheda **Elaborazione**: seleziona il prodotto, il sensore (`auto` va bene
+   nella maggior parte dei casi; per **PRISMA** e **HICO** scegli il sensore a mano),
+   il formato di output e i parametri.
+3. Premi **▶ Avvia Polymer**. Il registro di elaborazione scorre a schermo.
+4. Al termine trovi il risultato in `data/output/` e un'anteprima nell'interfaccia.
+
+Puoi selezionare **più prodotti insieme** per l'elaborazione in lotto.
+
+## 6. Fermare / aggiornare
+
+- Fermare: `docker compose -f docker/docker-compose.yml down`
+- Aggiornare dopo un `git pull`: riavvia con il launcher (ricostruisce se serve) o
+  `docker compose -f docker/docker-compose.yml up --build`.
+
+## Dove finiscono i dati
+
+Accanto al repository viene creata la cartella `data/`:
+
+| Cartella | Contenuto |
+|---|---|
+| `data/input` | prodotti Level-1 da elaborare (li metti tu) |
+| `data/output` | risultati Level-2 + `_jobs.log` (cronologia) |
+| `data/auxdata` | tabelle statiche di Polymer (scaricate una volta) |
+| `data/ancillary` | dati meteo scaricati automaticamente |
+| `data/config` | credenziali (`.netrc`, `.cdsapirc`) e consenso alla licenza |
+
+Nessuno di questi dati è dentro l'immagine: puoi cancellare e ricostruire
+l'immagine senza perdere configurazione e download.
+
+## Risoluzione problemi
+
+| Problema | Soluzione |
+|---|---|
+| «porta 8501 già in uso» | cambia `8501:8501` in `8502:8501` in `docker/docker-compose.yml` e vai su `http://localhost:8502` |
+| Build fallita a metà | `docker compose -f docker/docker-compose.yml build --no-cache` |
+| Elaborazione lenta su Mac Apple Silicon | normale: l'immagine è `linux/amd64` ed è emulata. Funziona, ma è più lenta. |
+| «out of memory» durante l'elaborazione | in Docker Desktop → *Settings → Resources* aumenta la RAM (consigliati ≥ 8 GB) |
+| Serve più spazio disco | l'immagine + dati ausiliari occupano ~6–7 GB |
+
+## Limiti noti
+
+- L'immagine è solo `linux/amd64` (il lock `environment.yml` è per quella piattaforma).
+- MODIS/VIIRS/SeaWiFS richiedono file **Level-1C** già preparati con `l2gen` (NASA
+  OBPG), non incluso qui.
+- L'interfaccia usa l'API v4 di Polymer (`run_atm_corr`), che copre tutti i sensori
+  elencati sopra.

--- a/docker/app/credentials.py
+++ b/docker/app/credentials.py
@@ -1,0 +1,103 @@
+"""
+Gestione delle credenziali per i dati meteo ausiliari.
+
+- NASA Earthdata  -> file  ~/.netrc      (machine urs.earthdata.nasa.gov ...)
+- Copernicus CDS  -> file  ~/.cdsapirc   (url + key)
+
+I file sono salvati in /data/config (montato dall'host) cosi' da sopravvivere ai
+riavvii del container.  HOME e' impostata a /data/config nel Dockerfile/entrypoint.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+CONFIG_DIR = Path(os.environ.get("HOME", "/data/config"))
+
+NETRC = CONFIG_DIR / ".netrc"
+CDSAPIRC = CONFIG_DIR / ".cdsapirc"
+
+EARTHDATA_MACHINE = "urs.earthdata.nasa.gov"
+CDS_URL = "https://cds.climate.copernicus.eu/api"
+
+
+# --------------------------------------------------------------------------- NASA
+def read_earthdata() -> dict:
+    """Ritorna {'login': ..., 'password': ...} se presenti nel .netrc, altrimenti {}."""
+    if not NETRC.exists():
+        return {}
+    tokens = NETRC.read_text().split()
+    out: dict[str, str] = {}
+    for i, tok in enumerate(tokens):
+        if tok == "machine" and i + 1 < len(tokens) and tokens[i + 1] == EARTHDATA_MACHINE:
+            rest = tokens[i + 2 :]
+            for j in range(0, len(rest) - 1, 2):
+                if rest[j] in ("login", "password"):
+                    out[rest[j]] = rest[j + 1]
+                if rest[j] == "machine":
+                    break
+    return out
+
+
+def write_earthdata(login: str, password: str) -> None:
+    """Crea/aggiorna la riga di Earthdata nel ~/.netrc senza toccare le altre."""
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    lines = []
+    if NETRC.exists():
+        lines = [
+            ln
+            for ln in NETRC.read_text().splitlines()
+            if EARTHDATA_MACHINE not in ln
+        ]
+    lines.append(
+        f"machine {EARTHDATA_MACHINE} login {login} password {password}"
+    )
+    NETRC.write_text("\n".join(ln for ln in lines if ln.strip()) + "\n")
+    NETRC.chmod(0o600)
+
+
+def clear_earthdata() -> None:
+    if NETRC.exists():
+        lines = [
+            ln for ln in NETRC.read_text().splitlines() if EARTHDATA_MACHINE not in ln
+        ]
+        if any(ln.strip() for ln in lines):
+            NETRC.write_text("\n".join(lines) + "\n")
+            NETRC.chmod(0o600)
+        else:
+            NETRC.unlink()
+
+
+# ---------------------------------------------------------------------------- CDS
+def read_cds() -> dict:
+    if not CDSAPIRC.exists():
+        return {}
+    out: dict[str, str] = {}
+    for ln in CDSAPIRC.read_text().splitlines():
+        if ":" in ln:
+            k, _, v = ln.partition(":")
+            out[k.strip()] = v.strip()
+    return out
+
+
+def write_cds(key: str, url: str = CDS_URL) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    CDSAPIRC.write_text(f"url: {url}\nkey: {key}\n")
+    CDSAPIRC.chmod(0o600)
+
+
+def clear_cds() -> None:
+    if CDSAPIRC.exists():
+        CDSAPIRC.unlink()
+
+
+# ------------------------------------------------------------------------- stato
+def status() -> dict:
+    """Riepilogo booleano per la pagina 'Stato configurazione'."""
+    ed = read_earthdata()
+    cds = read_cds()
+    return {
+        "earthdata": bool(ed.get("login") and ed.get("password")),
+        "earthdata_login": ed.get("login", ""),
+        "cds": bool(cds.get("key")),
+    }

--- a/docker/app/params_schema.py
+++ b/docker/app/params_schema.py
@@ -1,0 +1,102 @@
+"""
+Elenco curato dei parametri di Polymer esposti nell'interfaccia grafica.
+
+I significati derivano dalla docstring di ``run_atm_corr`` (polymer/main.py) e da
+``polymer/params.py``.  Tutto cio' che non e' qui resta comunque impostabile dalla
+sezione "Parametri avanzati" dell'interfaccia (passati come **kwargs).
+"""
+
+# Sensori riconosciuti dall'interfaccia. "auto" = rilevamento dal nome file.
+SENSORS = [
+    "auto",
+    "OLCI",       # Sentinel-3
+    "MSI",        # Sentinel-2
+    "MERIS",      # Envisat
+    "MODIS",      # Aqua
+    "VIIRS",
+    "SeaWiFS",
+    "PRISMA",
+    "LANDSAT8",
+    "HICO",
+]
+
+# Sensori la cui autodetezione dal nome file NON e' supportata da polymer.level1.Level1
+NEEDS_EXPLICIT_SENSOR = {"PRISMA", "HICO"}
+
+OUTPUT_FORMATS = ["netcdf4", "hdf4"]
+
+WATER_MODELS = {
+    "PR05": "Park & Ruddick 2005 (predefinito, consigliato)",
+    "MM01": "Morel & Maritorena 2001",
+    "MM01_FOQ": "Morel & Maritorena 2001 con f/Q direzionale",
+}
+
+NORMALIZE = {
+    0: "Nessuna normalizzazione",
+    1: "Normalizza la riflettanza dell'acqua al nadir",
+    2: "Normalizzazione in lunghezza d'onda (MERIS/OLCI)",
+    3: "Entrambe (nadir + lunghezza d'onda)",
+}
+
+ANCILLARY_SOURCES = {
+    "auto": "Automatico (usa NASA se disponibili le credenziali)",
+    "NASA": "NASA Earthdata (ozono, vento, pressione)",
+    "ERA5": "Copernicus ERA5 / CDS",
+    "none": "Nessuno (usa le climatologie interne)",
+}
+
+# Campi "comuni" mostrati sempre nel modulo di elaborazione.
+# tipo: text | int | float | bool | choice
+COMMON_PARAMS = [
+    {
+        "name": "multiprocessing",
+        "label": "Numero di core CPU",
+        "type": "int",
+        "default": -1,
+        "help": "0 = un solo core.  -1 = tutti i core disponibili.  N = N core.",
+    },
+    {
+        "name": "sline",
+        "label": "Riga iniziale (ritaglio)",
+        "type": "int",
+        "default": 0,
+        "help": "Ritaglia il prodotto: prima riga da elaborare (0 = dall'inizio).",
+    },
+    {
+        "name": "eline",
+        "label": "Riga finale (ritaglio)",
+        "type": "int",
+        "default": -1,
+        "help": "Ultima riga da elaborare (-1 = fino alla fine).",
+    },
+    {
+        "name": "scol",
+        "label": "Colonna iniziale (ritaglio)",
+        "type": "int",
+        "default": 0,
+        "help": "Prima colonna da elaborare (0 = dall'inizio). Ignorato da alcuni sensori.",
+    },
+    {
+        "name": "ecol",
+        "label": "Colonna finale (ritaglio)",
+        "type": "int",
+        "default": -1,
+        "help": "Ultima colonna da elaborare (-1 = fino alla fine).",
+    },
+]
+
+# Etichette leggibili per i flag di qualita' di Polymer (polymer/common.py).
+L2_FLAGS = {
+    "LAND": 1,
+    "CLOUD_BASE": 2,
+    "L1_INVALID": 4,
+    "NEGATIVE_BB": 8,
+    "OUT_OF_BOUNDS": 16,
+    "EXCEPTION": 32,
+    "THICK_AEROSOL": 64,
+    "HIGH_AIR_MASS": 128,
+    "EXTERNAL_MASK": 512,
+    "CASE2": 1024,
+    "INCONSISTENCY": 2048,
+    "ANOMALY_RWMOD_BLUE": 4096,
+}

--- a/docker/app/polymer_job.py
+++ b/docker/app/polymer_job.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+"""
+Esecuzione di un singolo job Polymer, come sottoprocesso indipendente.
+
+Uso:
+    python polymer_job.py --config /percorso/job.json
+
+Struttura di job.json:
+{
+    "input":   "/data/input/S3A_..._.SEN3",
+    "sensor":  "auto" | "OLCI" | "MSI" | "MERIS" | "MODIS" | "VIIRS"
+                     | "SeaWiFS" | "PRISMA" | "LANDSAT8" | "HICO",
+    "output_dir": "/data/output",
+    "output_name": "" ,          # opzionale: nome file esplicito
+    "fmt":     "netcdf4" | "hdf4",
+    "resolution": "60",          # solo MSI: "10" | "20" | "60"
+    "ancillary": "auto" | "NASA" | "ERA5" | "none",
+    "l1_kwargs":     {"sline": 0, "eline": -1, "scol": 0, "ecol": -1},
+    "polymer_kwargs": {"multiprocessing": -1, "normalize": 0, ...}
+}
+
+Il sottoprocesso stampa il progresso su stdout (Polymer logga gia' le percentuali)
+ed esce con codice 0 (successo) o 1 (errore, con traceback completo su stderr).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+
+def build_level1(cfg: dict):
+    from polymer.level1 import Level1
+
+    src = cfg["input"]
+    sensor = (cfg.get("sensor") or "auto").lower()
+    l1_kwargs = dict(cfg.get("l1_kwargs") or {})
+
+    anc = build_ancillary(cfg.get("ancillary", "auto"))
+    if anc is not None:
+        l1_kwargs["ancillary"] = anc
+
+    if sensor in ("", "auto"):
+        return Level1(src, **l1_kwargs)
+
+    if sensor == "olci":
+        from polymer.level1_olci import Level1_OLCI
+        return Level1_OLCI(src, **l1_kwargs)
+    if sensor == "msi":
+        from polymer.level1_msi import Level1_MSI
+        res = str(cfg.get("resolution") or "60")
+        return Level1_MSI(src, resolution=res, **l1_kwargs)
+    if sensor == "meris":
+        from polymer.level1_meris import Level1_MERIS
+        return Level1_MERIS(src, **l1_kwargs)
+    if sensor in ("modis", "viirs", "seawifs"):
+        from polymer.level1_nasa import Level1_MODIS, Level1_SeaWiFS, Level1_VIIRS
+        cls = {"modis": Level1_MODIS, "viirs": Level1_VIIRS, "seawifs": Level1_SeaWiFS}[sensor]
+        return cls(src, **l1_kwargs)
+    if sensor == "prisma":
+        from polymer.level1_prisma import Level1_PRISMA
+        return Level1_PRISMA(src, **l1_kwargs)
+    if sensor == "landsat8":
+        from polymer.level1_landsat8 import Level1_OLI
+        return Level1_OLI(src, **l1_kwargs)
+    if sensor == "hico":
+        from polymer.level1_hico import Level1_HICO
+        return Level1_HICO(src, **l1_kwargs)
+
+    raise ValueError(f"Sensore non riconosciuto: {sensor!r}")
+
+
+def build_ancillary(kind: str):
+    kind = (kind or "auto").lower()
+    if kind == "none":
+        return None
+    if kind == "era5":
+        from polymer.ancillary_era5 import Ancillary_ERA5
+        return Ancillary_ERA5()
+    if kind == "nasa":
+        from polymer.ancillary import Ancillary_NASA
+        return Ancillary_NASA()
+    # auto: usa NASA solo se il .netrc contiene le credenziali Earthdata
+    netrc = Path(os.environ.get("HOME", "/data/config")) / ".netrc"
+    if netrc.exists() and "urs.earthdata.nasa.gov" in netrc.read_text():
+        from polymer.ancillary import Ancillary_NASA
+        return Ancillary_NASA()
+    return None
+
+
+def build_level2(cfg: dict):
+    from polymer.level2 import Level2
+
+    fmt = cfg.get("fmt", "netcdf4")
+    out_dir = cfg.get("output_dir") or "/data/output"
+    name = (cfg.get("output_name") or "").strip()
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+
+    if name:
+        filename = str(Path(out_dir) / name)
+        return Level2(filename=filename, fmt=fmt, overwrite=True)
+    ext = ".polymer.nc" if fmt == "netcdf4" else ".polymer.hdf"
+    return Level2(fmt=fmt, outdir=out_dir, ext=ext, overwrite=True)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True)
+    args = ap.parse_args()
+
+    cfg = json.loads(Path(args.config).read_text())
+
+    pk = dict(cfg.get("polymer_kwargs") or {})
+    # OMP_NUM_THREADS: limita il multiprocessing di numpy quando Polymer gia' parallelizza
+    mp = int(pk.get("multiprocessing", 0) or 0)
+    os.environ.setdefault("OMP_NUM_THREADS", "1" if mp != 0 else str(os.cpu_count() or 1))
+
+    print(f"[polymer_job] input   = {cfg['input']}", flush=True)
+    print(f"[polymer_job] sensore = {cfg.get('sensor', 'auto')}", flush=True)
+    print(f"[polymer_job] output  = {cfg.get('output_dir')}  ({cfg.get('fmt')})", flush=True)
+    print(f"[polymer_job] kwargs  = {pk}", flush=True)
+
+    from polymer.main import run_atm_corr
+
+    l1 = build_level1(cfg)
+    l2 = build_level2(cfg)
+    result = run_atm_corr(l1, l2, **pk)
+
+    out = getattr(result, "filename", None) or cfg.get("output_dir")
+    print(f"[polymer_job] COMPLETATO -> {out}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        traceback.print_exc()
+        sys.exit(1)

--- a/docker/app/quicklook.py
+++ b/docker/app/quicklook.py
@@ -1,0 +1,95 @@
+"""
+Anteprima PNG di un prodotto Level-2 di Polymer.
+
+Prova, in ordine:
+  1. RGB dalla riflettanza dell'acqua (Rw/rho_w a ~665/560/443 nm)
+  2. mappa di logchl / logchl_mean
+  3. prima variabile 2D disponibile
+"""
+from __future__ import annotations
+
+import numpy as np
+
+_RGB = {"r": 665, "g": 560, "b": 443}
+
+
+def _open(path: str):
+    import xarray as xr
+
+    try:
+        return xr.open_dataset(path)
+    except Exception:
+        return xr.open_dataset(path, engine="netcdf4")
+
+
+def _find_band_var(ds, prefixes, wl):
+    for pref in prefixes:
+        name = f"{pref}{wl}"
+        if name in ds.variables:
+            return ds[name]
+    for pref in prefixes:
+        if pref in ds.variables and "bands" in ds[pref].dims and "bands" in ds:
+            bands = np.asarray(ds["bands"].values)
+            idx = int(np.argmin(np.abs(bands - wl)))
+            return ds[pref].isel(bands=idx)
+    return None
+
+
+def _stretch(a):
+    a = np.asarray(a, dtype="float32")
+    finite = a[np.isfinite(a)]
+    if finite.size == 0:
+        return np.zeros_like(a)
+    lo, hi = np.percentile(finite, [2, 98])
+    if hi <= lo:
+        hi = lo + 1e-6
+    return np.clip((a - lo) / (hi - lo), 0, 1)
+
+
+def make_png(level2_path: str, out_png: str) -> str:
+    """Genera `out_png` e restituisce una breve descrizione di cosa mostra."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    ds = _open(level2_path)
+    try:
+        prefixes = ["rho_w_", "Rw", "rho_w"]
+        r = _find_band_var(ds, prefixes, _RGB["r"])
+        g = _find_band_var(ds, prefixes, _RGB["g"])
+        b = _find_band_var(ds, prefixes, _RGB["b"])
+
+        fig, ax = plt.subplots(figsize=(7, 7))
+        if r is not None and g is not None and b is not None:
+            rgb = np.dstack([_stretch(r.values), _stretch(g.values), _stretch(b.values)])
+            ax.imshow(rgb, origin="upper")
+            desc = "RGB della riflettanza dell'acqua (665 / 560 / 443 nm)"
+        else:
+            chl = None
+            for cand in ("logchl", "logchl_mean", "logchl_stdev"):
+                if cand in ds.variables:
+                    chl = ds[cand]
+                    break
+            if chl is None:
+                twod = [
+                    v for v in ds.data_vars
+                    if ds[v].ndim == 2 and set(ds[v].dims) <= {"height", "width", "y", "x"}
+                ]
+                if not twod:
+                    raise RuntimeError("Nessuna variabile 2D adatta per l'anteprima.")
+                chl = ds[twod[0]]
+                desc = f"Mappa di '{twod[0]}'"
+            else:
+                desc = f"Mappa di '{chl.name}' (log clorofilla)"
+            im = ax.imshow(chl.values, origin="upper", cmap="viridis")
+            fig.colorbar(im, ax=ax, shrink=0.8)
+        ax.set_title(desc, fontsize=10)
+        ax.set_xticks([])
+        ax.set_yticks([])
+        fig.tight_layout()
+        fig.savefig(out_png, dpi=110)
+        plt.close(fig)
+        return desc
+    finally:
+        ds.close()

--- a/docker/app/setup_status.py
+++ b/docker/app/setup_status.py
@@ -1,0 +1,49 @@
+"""
+Controlli di stato mostrati nella pagina "Stato configurazione".
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+AUXDATA_DIR = Path(os.environ.get("DIR_POLYMER_AUXDATA", "/data/auxdata/static"))
+ANCILLARY_DIR = Path(os.environ.get("DIR_POLYMER_ANCILLARY", "/data/ancillary"))
+INPUT_DIR = Path("/data/input")
+OUTPUT_DIR = Path("/data/output")
+
+# File chiave che deve esistere dopo "python -m polymer.get_auxdata".
+AUXDATA_SENTINEL = AUXDATA_DIR / "generic" / "LUT.hdf"
+
+
+def cython_modules_ok() -> bool:
+    try:
+        import polymer.polymer_main  # noqa: F401
+        import polymer.water  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def auxdata_present() -> bool:
+    return AUXDATA_SENTINEL.exists() and AUXDATA_SENTINEL.stat().st_size > 0
+
+
+def auxdata_size_mb() -> float:
+    if not AUXDATA_DIR.exists():
+        return 0.0
+    total = sum(f.stat().st_size for f in AUXDATA_DIR.rglob("*") if f.is_file())
+    return total / (1024 * 1024)
+
+
+def list_input_products() -> list[str]:
+    """Elenca i possibili prodotti Level-1 in /data/input (file e cartelle di 1o livello)."""
+    if not INPUT_DIR.exists():
+        return []
+    items = sorted(
+        p.name for p in INPUT_DIR.iterdir() if not p.name.startswith(".")
+    )
+    return items
+
+
+def overall_ready() -> bool:
+    return cython_modules_ok() and auxdata_present()

--- a/docker/app/streamlit_app.py
+++ b/docker/app/streamlit_app.py
@@ -1,0 +1,440 @@
+"""
+Interfaccia grafica per Polymer (correzione atmosferica del colore dell'oceano).
+
+Si apre nel browser su http://localhost:8501 quando il container e' in esecuzione.
+Nessun comando da digitare: tutti i parametri si impostano da qui.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+import streamlit as st
+
+import credentials as cred
+import setup_status as status
+from params_schema import (
+    ANCILLARY_SOURCES,
+    COMMON_PARAMS,
+    NEEDS_EXPLICIT_SENSOR,
+    NORMALIZE,
+    OUTPUT_FORMATS,
+    SENSORS,
+    WATER_MODELS,
+)
+
+APP_DIR = Path(__file__).parent
+LICENCE_FILE = APP_DIR / "LICENCE.TXT"
+CONFIG_DIR = Path(os.environ.get("HOME", "/data/config"))
+LICENCE_FLAG = CONFIG_DIR / ".polymer_licence_accepted"
+OUTPUT_DIR = Path("/data/output")
+JOBS_LOG = OUTPUT_DIR / "_jobs.log"
+JOB_TMP = CONFIG_DIR / "_job.json"
+
+st.set_page_config(page_title="Polymer", page_icon="🌊", layout="wide")
+
+
+# --------------------------------------------------------------------------- util
+def stream_command(cmd: list[str], env: dict | None = None) -> int:
+    """Esegue `cmd`, riversa stdout/stderr in un box a schermo, ritorna l'exit code."""
+    box = st.empty()
+    lines: list[str] = []
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        env={**os.environ, **(env or {})},
+    )
+    assert proc.stdout is not None
+    for line in proc.stdout:
+        lines.append(line.rstrip())
+        box.code("\n".join(lines[-400:]), language="text")
+    proc.wait()
+    return proc.returncode
+
+
+def append_job_log(entry: dict) -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    with JOBS_LOG.open("a") as fh:
+        fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+
+def read_job_log() -> list[dict]:
+    if not JOBS_LOG.exists():
+        return []
+    out = []
+    for ln in JOBS_LOG.read_text().splitlines():
+        try:
+            out.append(json.loads(ln))
+        except Exception:
+            pass
+    return out[::-1]
+
+
+# ------------------------------------------------------------------ gate: licenza
+def licence_gate() -> bool:
+    if LICENCE_FLAG.exists():
+        return True
+    st.title("🌊 Polymer — Termini d'uso")
+    st.warning(
+        "Prima di usare Polymer devi accettare i Termini d'uso di HYGEOS. "
+        "In sintesi: uso gratuito **solo per scopi non commerciali** e **non ridistribuibile**."
+    )
+    if LICENCE_FILE.exists():
+        st.text_area("LICENCE.TXT", LICENCE_FILE.read_text(), height=320)
+    agree = st.checkbox("Ho letto e accetto i Termini d'uso di Polymer")
+    if st.button("Continua", disabled=not agree, type="primary"):
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        LICENCE_FLAG.write_text(datetime.now().isoformat())
+        st.rerun()
+    return False
+
+
+# ---------------------------------------------------------------- sidebar / stato
+def sidebar_status() -> None:
+    st.sidebar.header("Stato configurazione")
+
+    ok_cy = status.cython_modules_ok()
+    st.sidebar.write(("✅" if ok_cy else "❌") + " Moduli di calcolo compilati")
+
+    ok_aux = status.auxdata_present()
+    size = status.auxdata_size_mb()
+    st.sidebar.write(
+        ("✅" if ok_aux else "⬇️") + f" Dati ausiliari statici ({size:.0f} MB)"
+    )
+
+    cs = cred.status()
+    st.sidebar.write(
+        ("✅" if cs["earthdata"] else "➖")
+        + " NASA Earthdata"
+        + (f" ({cs['earthdata_login']})" if cs["earthdata"] else "")
+    )
+    st.sidebar.write(("✅" if cs["cds"] else "➖") + " Copernicus CDS / ERA5")
+
+    st.sidebar.divider()
+    if not ok_aux:
+        st.sidebar.info("Scarica i dati ausiliari dalla scheda **Configurazione**.")
+    st.sidebar.caption(
+        "Cartelle sull'host:\n\n"
+        "`data/input` → prodotti Level-1\n\n"
+        "`data/output` → risultati\n\n"
+        "`data/config` → credenziali"
+    )
+
+
+# --------------------------------------------------------- scheda: configurazione
+def tab_config() -> None:
+    st.subheader("Dati ausiliari statici")
+    st.write(
+        "Polymer ha bisogno di alcune tabelle di riferimento (circa 1 GB, incluso "
+        "`LUT.hdf`). Si scaricano **una sola volta** nella cartella `data/auxdata`."
+    )
+    if status.auxdata_present():
+        st.success(f"Dati ausiliari presenti ({status.auxdata_size_mb():.0f} MB).")
+    if st.button("Scarica / aggiorna dati ausiliari", type="primary"):
+        rc = stream_command([sys.executable, "-m", "polymer.get_auxdata"])
+        if rc == 0:
+            st.success("Download completato.")
+        else:
+            st.error(f"Download fallito (codice {rc}). Controlla la connessione e riprova.")
+
+    st.divider()
+    st.subheader("Credenziali dati meteo (facoltative)")
+    st.write(
+        "Servono per scaricare **al volo** ozono, vento e pressione. Senza credenziali "
+        "Polymer usa comunque delle climatologie interne."
+    )
+
+    src = st.radio(
+        "Fonte dei dati meteo",
+        options=list(ANCILLARY_SOURCES.keys()),
+        format_func=lambda k: ANCILLARY_SOURCES[k],
+        horizontal=False,
+        key="anc_source_config",
+    )
+
+    if src == "NASA":
+        ed = cred.read_earthdata()
+        with st.form("form_nasa"):
+            login = st.text_input("Nome utente Earthdata", value=ed.get("login", ""))
+            pw = st.text_input("Password Earthdata", type="password")
+            c1, c2 = st.columns(2)
+            save = c1.form_submit_button("Salva credenziali NASA", type="primary")
+            clear = c2.form_submit_button("Rimuovi")
+        if save:
+            if login and pw:
+                cred.write_earthdata(login, pw)
+                st.success("Credenziali NASA salvate in data/config/.netrc")
+                st.rerun()
+            else:
+                st.error("Inserisci sia nome utente sia password.")
+        if clear:
+            cred.clear_earthdata()
+            st.info("Credenziali NASA rimosse.")
+            st.rerun()
+        st.caption(
+            "Registrazione gratuita: https://urs.earthdata.nasa.gov/users/new — "
+            "ricorda di autorizzare l'applicazione «NASA GESDISC DATA ARCHIVE»."
+        )
+
+    elif src == "ERA5":
+        cds = cred.read_cds()
+        with st.form("form_cds"):
+            key = st.text_input(
+                "CDS API key", value=cds.get("key", ""),
+                help="La trovi nella tua pagina profilo su cds.climate.copernicus.eu",
+            )
+            c1, c2 = st.columns(2)
+            save = c1.form_submit_button("Salva API key CDS", type="primary")
+            clear = c2.form_submit_button("Rimuovi")
+        if save:
+            if key.strip():
+                cred.write_cds(key.strip())
+                st.success("API key salvata in data/config/.cdsapirc")
+                st.rerun()
+            else:
+                st.error("Inserisci la API key.")
+        if clear:
+            cred.clear_cds()
+            st.info("API key CDS rimossa.")
+            st.rerun()
+        st.caption("Registrazione gratuita: https://cds.climate.copernicus.eu/user/register")
+
+    else:
+        st.info("Nessuna credenziale richiesta per questa scelta.")
+
+
+# ------------------------------------------------------- costruzione config job
+def build_job_config(
+    input_path: str,
+    sensor: str,
+    fmt: str,
+    resolution: str,
+    ancillary: str,
+    output_name: str,
+    common_vals: dict,
+    advanced: dict,
+) -> dict:
+    # Passa i parametri di ritaglio solo se l'utente li ha cambiati dai default
+    # (0 / -1): alcune classi Level1 non accettano scol/ecol.
+    _crop_defaults = {"sline": 0, "eline": -1, "scol": 0, "ecol": -1}
+    l1_kwargs = {
+        k: int(common_vals[k])
+        for k, dflt in _crop_defaults.items()
+        if k in common_vals and int(common_vals[k]) != dflt
+    }
+    polymer_kwargs: dict = {"multiprocessing": int(common_vals.get("multiprocessing", 0))}
+    if common_vals.get("water_model"):
+        polymer_kwargs["water_model"] = common_vals["water_model"]
+    if common_vals.get("normalize") is not None:
+        polymer_kwargs["normalize"] = int(common_vals["normalize"])
+    if common_vals.get("force_initialization"):
+        polymer_kwargs["force_initialization"] = True
+    polymer_kwargs.update(advanced)
+
+    return {
+        "input": input_path,
+        "sensor": sensor,
+        "output_dir": str(OUTPUT_DIR),
+        "output_name": output_name,
+        "fmt": fmt,
+        "resolution": resolution,
+        "ancillary": ancillary,
+        "l1_kwargs": l1_kwargs,
+        "polymer_kwargs": polymer_kwargs,
+    }
+
+
+def parse_advanced(text: str) -> dict:
+    """Converte righe 'chiave = valore' in un dizionario (valori come JSON se possibile)."""
+    out: dict = {}
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw or raw.startswith("#") or "=" not in raw:
+            continue
+        k, _, v = raw.partition("=")
+        k, v = k.strip(), v.strip()
+        try:
+            out[k] = json.loads(v)
+        except Exception:
+            out[k] = v
+    return out
+
+
+def run_job(cfg: dict) -> None:
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    JOB_TMP.write_text(json.dumps(cfg, indent=2))
+    st.write(f"**Elaborazione di:** `{cfg['input']}`")
+    t0 = time.time()
+    rc = stream_command([sys.executable, str(APP_DIR / "polymer_job.py"), "--config", str(JOB_TMP)])
+    dt = time.time() - t0
+    entry = {
+        "quando": datetime.now().isoformat(timespec="seconds"),
+        "input": cfg["input"],
+        "sensore": cfg["sensor"],
+        "formato": cfg["fmt"],
+        "durata_s": round(dt, 1),
+        "esito": "ok" if rc == 0 else f"errore ({rc})",
+    }
+    append_job_log(entry)
+
+    if rc != 0:
+        st.error(f"Elaborazione fallita (codice {rc}). Vedi il log qui sopra.")
+        return
+    st.success(f"Completato in {dt:.0f} s. Risultati in `data/output/`.")
+
+    newest = _newest_output()
+    if newest is not None:
+        st.write(f"**File prodotto:** `{newest.name}` ({newest.stat().st_size/1e6:.1f} MB)")
+        try:
+            import quicklook
+
+            png = CONFIG_DIR / "_preview.png"
+            desc = quicklook.make_png(str(newest), str(png))
+            st.image(str(png), caption=desc, use_container_width=True)
+        except Exception as exc:  # anteprima non critica
+            st.caption(f"(Anteprima non disponibile: {exc})")
+
+
+def _newest_output() -> Path | None:
+    if not OUTPUT_DIR.exists():
+        return None
+    files = [
+        p for p in OUTPUT_DIR.iterdir()
+        if p.is_file() and p.suffix in (".nc", ".hdf") and not p.name.startswith("_")
+    ]
+    return max(files, key=lambda p: p.stat().st_mtime) if files else None
+
+
+# ---------------------------------------------------------- scheda: elaborazione
+def tab_process() -> None:
+    if not status.overall_ready():
+        st.warning(
+            "Configurazione incompleta: servono i moduli compilati e i dati ausiliari. "
+            "Apri la scheda **Configurazione**."
+        )
+
+    products = status.list_input_products()
+    if not products:
+        st.info(
+            "Nessun prodotto in `data/input/`. Copia lì i tuoi prodotti Level-1 "
+            "(cartelle `.SEN3`, `.SAFE`, file `.N1`, `.L1C`, `.he5` …) e ricarica la pagina."
+        )
+        return
+
+    col_l, col_r = st.columns([2, 1])
+    with col_l:
+        selected = st.multiselect(
+            "Prodotti Level-1 da elaborare",
+            products,
+            default=products[:1],
+            help="Selezionane più di uno per l'elaborazione in lotto.",
+        )
+    with col_r:
+        sensor = st.selectbox("Sensore", SENSORS, index=0)
+        fmt = st.selectbox("Formato di output", OUTPUT_FORMATS, index=0)
+
+    resolution = "60"
+    if sensor == "MSI":
+        resolution = st.selectbox("Risoluzione MSI (m)", ["10", "20", "60"], index=2)
+    if sensor in NEEDS_EXPLICIT_SENSOR:
+        st.caption(
+            f"Il sensore {sensor} non è rilevabile automaticamente: selezionalo qui esplicitamente."
+        )
+
+    ancillary = st.selectbox(
+        "Dati meteo ausiliari",
+        list(ANCILLARY_SOURCES.keys()),
+        format_func=lambda k: ANCILLARY_SOURCES[k],
+        index=0,
+    )
+
+    st.markdown("**Parametri comuni**")
+    common_vals: dict = {}
+    cols = st.columns(3)
+    for i, p in enumerate(COMMON_PARAMS):
+        with cols[i % 3]:
+            common_vals[p["name"]] = st.number_input(
+                p["label"], value=int(p["default"]), step=1, help=p["help"], key=f"cp_{p['name']}"
+            )
+    c1, c2, c3 = st.columns(3)
+    common_vals["water_model"] = c1.selectbox(
+        "Modello dell'acqua", list(WATER_MODELS.keys()),
+        format_func=lambda k: WATER_MODELS[k], index=0,
+    )
+    common_vals["normalize"] = c2.selectbox(
+        "Normalizzazione", list(NORMALIZE.keys()),
+        format_func=lambda k: NORMALIZE[k], index=0,
+    )
+    common_vals["force_initialization"] = c3.checkbox("force_initialization", value=False)
+
+    with st.expander("Parametri avanzati (una coppia « nome = valore » per riga)"):
+        st.caption(
+            "Passati direttamente a `run_atm_corr`. Riferimento: `polymer/params.py`. "
+            "Esempi:\n\n`Rprime_consistency = false`\n\n`calib = null`"
+        )
+        advanced_text = st.text_area("Avanzati", value="", height=140, label_visibility="collapsed")
+
+    output_name = ""
+    if len(selected) == 1:
+        output_name = st.text_input(
+            "Nome file di output (facoltativo)", value="",
+            help="Vuoto = nome automatico basato sul prodotto di input.",
+        )
+
+    if st.button("▶ Avvia Polymer", type="primary", disabled=not selected):
+        advanced = parse_advanced(advanced_text)
+        progress = st.progress(0.0)
+        for idx, name in enumerate(selected):
+            st.divider()
+            st.markdown(f"### {idx + 1}/{len(selected)} — {name}")
+            cfg = build_job_config(
+                input_path=str(Path("/data/input") / name),
+                sensor=sensor,
+                fmt=fmt,
+                resolution=resolution,
+                ancillary=ancillary,
+                output_name=output_name if len(selected) == 1 else "",
+                common_vals=common_vals,
+                advanced=advanced,
+            )
+            run_job(cfg)
+            progress.progress((idx + 1) / len(selected))
+        st.balloons()
+
+
+# -------------------------------------------------------------- scheda: cronologia
+def tab_history() -> None:
+    rows = read_job_log()
+    if not rows:
+        st.info("Nessuna elaborazione registrata finora.")
+        return
+    st.dataframe(rows, use_container_width=True, hide_index=True)
+
+
+# ----------------------------------------------------------------------------- main
+def main() -> None:
+    if not licence_gate():
+        return
+    sidebar_status()
+    st.title("🌊 Polymer")
+    st.caption("Correzione atmosferica del colore dell'oceano — HYGEOS")
+
+    t_proc, t_conf, t_hist = st.tabs(["Elaborazione", "Configurazione", "Cronologia"])
+    with t_proc:
+        tab_process()
+    with t_conf:
+        tab_config()
+    with t_hist:
+        tab_history()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+# Avvio di Polymer con interfaccia grafica.
+#
+# Prima volta (costruisce l'immagine, 10-20 minuti):
+#   docker compose -f docker/docker-compose.yml up --build
+# Volte successive:
+#   docker compose -f docker/docker-compose.yml up
+# Poi apri il browser su http://localhost:8501
+#
+# I dati stanno nella cartella ./data accanto al repository:
+#   data/input      -> metti qui i prodotti satellitari Level-1
+#   data/output     -> qui compaiono i risultati Level-2
+#   data/auxdata    -> dati statici di Polymer (scaricati una volta sola)
+#   data/ancillary  -> dati meteo scaricati automaticamente
+#   data/config     -> credenziali salvate dall'interfaccia
+
+name: polymer
+
+services:
+  polymer:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: polymer-gui:local
+    platform: linux/amd64
+    container_name: polymer-gui
+    ports:
+      - "8501:8501"
+    volumes:
+      - ../data/input:/data/input
+      - ../data/output:/data/output
+      - ../data/auxdata:/data/auxdata
+      - ../data/ancillary:/data/ancillary
+      - ../data/config:/data/config
+    shm_size: "2gb"
+    restart: "no"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Avvio del container: prepara le cartelle dati, collega le credenziali e lancia
+# l'interfaccia web di Polymer.
+set -euo pipefail
+
+echo "==> Preparazione cartelle dati in /data ..."
+mkdir -p /data/input /data/output /data/auxdata/static /data/ancillary /data/config
+
+# Le credenziali (.netrc per NASA Earthdata, .cdsapirc per Copernicus CDS) sono
+# salvate dall'interfaccia in /data/config e devono essere visibili in $HOME.
+export HOME=/data/config
+for f in .netrc .cdsapirc; do
+    if [ -f "/data/config/$f" ]; then
+        chmod 600 "/data/config/$f" || true
+        echo "==> Credenziali trovate: $f"
+    fi
+done
+
+# Verifica che i moduli Cython siano stati compilati nell'immagine.
+if ! micromamba run -n polymer python -c "import polymer.polymer_main" 2>/dev/null; then
+    echo "ERRORE: i moduli compilati di Polymer non sono disponibili." >&2
+    echo "        Ricostruisci l'immagine con:  docker compose build --no-cache" >&2
+    exit 1
+fi
+
+echo "==> Interfaccia disponibile su http://localhost:8501"
+exec micromamba run -n polymer streamlit run /app/streamlit_app.py \
+    --server.port=8501 \
+    --server.address=0.0.0.0 \
+    --server.headless=true \
+    --browser.gatherUsageStats=false \
+    --server.fileWatcherType=none

--- a/docker/launchers/Avvia-Polymer-Windows.bat
+++ b/docker/launchers/Avvia-Polymer-Windows.bat
@@ -1,0 +1,59 @@
+@echo off
+REM Doppio clic per avviare Polymer con interfaccia grafica (Windows).
+setlocal
+
+cd /d "%~dp0\.."
+for %%I in ("%cd%\..") do set "REPO_ROOT=%%~fI"
+cd /d "%REPO_ROOT%"
+
+echo ======================================================
+echo   Polymer - avvio del container
+echo   Cartella: %REPO_ROOT%
+echo ======================================================
+echo.
+
+where docker >nul 2>&1
+if errorlevel 1 (
+  echo Docker non e' installato. Scaricalo da:
+  echo   https://www.docker.com/products/docker-desktop/
+  echo.
+  pause
+  exit /b 1
+)
+
+docker info >nul 2>&1
+if errorlevel 1 (
+  echo Docker e' installato ma non e' in esecuzione.
+  echo Apri "Docker Desktop", aspetta che sia pronto, poi riprova.
+  echo.
+  pause
+  exit /b 1
+)
+
+if not exist data\input      mkdir data\input
+if not exist data\output     mkdir data\output
+if not exist data\auxdata    mkdir data\auxdata
+if not exist data\ancillary  mkdir data\ancillary
+if not exist data\config     mkdir data\config
+
+echo.
+echo Costruzione/avvio in corso. La PRIMA volta richiede 10-20 minuti.
+echo.
+docker compose -f docker/docker-compose.yml up -d --build
+if errorlevel 1 (
+  echo.
+  echo Avvio fallito. Controlla i messaggi qui sopra.
+  pause
+  exit /b 1
+)
+
+echo.
+echo Attendo che l'interfaccia sia pronta...
+timeout /t 8 /nobreak >nul
+start "" "http://localhost:8501"
+
+echo.
+echo Polymer e' avviato su http://localhost:8501
+echo Per fermarlo:  docker compose -f docker/docker-compose.yml down
+echo.
+pause

--- a/docker/launchers/Avvia-Polymer-macOS-Linux.command
+++ b/docker/launchers/Avvia-Polymer-macOS-Linux.command
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Doppio clic per avviare Polymer con interfaccia grafica (macOS / Linux).
+# Su macOS: se compare "autore non identificato", tasto destro > Apri la prima volta.
+
+set -e
+cd "$(dirname "$0")/.."          # -> cartella docker/
+REPO_ROOT="$(cd .. && pwd)"
+cd "$REPO_ROOT"
+
+echo "======================================================"
+echo "  Polymer — avvio del container"
+echo "  Cartella: $REPO_ROOT"
+echo "======================================================"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo
+  echo "Docker non è installato. Scaricalo da:"
+  echo "  https://www.docker.com/products/docker-desktop/"
+  echo
+  read -r -p "Premi Invio per chiudere." _
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  echo
+  echo "Docker è installato ma non è in esecuzione."
+  echo "Apri 'Docker Desktop', aspetta che sia pronto, poi riprova."
+  echo
+  read -r -p "Premi Invio per chiudere." _
+  exit 1
+fi
+
+mkdir -p data/input data/output data/auxdata data/ancillary data/config
+
+echo
+echo "Costruzione/avvio in corso. La PRIMA volta richiede 10-20 minuti."
+echo
+docker compose -f docker/docker-compose.yml up -d --build
+
+echo
+echo "Attendo che l'interfaccia sia pronta..."
+for _ in $(seq 1 60); do
+  if curl -sf http://localhost:8501 >/dev/null 2>&1; then break; fi
+  sleep 2
+done
+
+URL="http://localhost:8501"
+echo "Apro $URL nel browser."
+if command -v open >/dev/null 2>&1; then open "$URL"
+elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$URL"
+fi
+
+echo
+echo "Polymer è avviato. Per fermarlo:"
+echo "  docker compose -f docker/docker-compose.yml down"
+echo
+read -r -p "Premi Invio per chiudere questa finestra (il container resta attivo)." _


### PR DESCRIPTION
Installing Polymer by hand requires a conda/pixi environment with dozens of scientific dependencies, compiling Cython modules via meson, downloading auxiliary data, and managing external credentials. This makes it hard to use for non-technical people.

This adds a self-contained Docker image plus a Streamlit web UI so anyone can install Docker Desktop, double-click a launcher, and run Polymer from a browser page (http://localhost:8501) instead of the command line or Python scripts.

What's included (all under docker/, no changes to Polymer's own code):
- Dockerfile: recreates the conda env from environment.yml, compiles the Cython modules, adds Streamlit. linux/amd64 only (environment.yml is a linux-64 lock; runs emulated on Apple Silicon). Sets DIR_DATA/DIR_POLYMER_* so core.env.getdir resolves at import time.
- docker-compose.yml + launcher scripts (.command / .bat) for a double-click start.
- Streamlit app: licence acceptance gate, setup status, dynamic credential forms for NASA Earthdata (.netrc) and Copernicus CDS/ERA5 (.cdsapirc), auxiliary-data download, single and batch processing driving polymer_job.py (a subprocess wrapper around run_atm_corr, v4 API for full sensor coverage incl. MSI/PRISMA), live log streaming, PNG quicklook, job history.
- README_DOCKER.md: step-by-step guide for non-technical users.
- .github/workflows/docker-build.yml: CI that builds the image (never pushes).

Distribution: per LICENCE.TXT Section 2 the Polymer software must not be redistributed, so only the build recipe is shipped; each user builds the image locally and accepts Polymer's terms in the UI on first run.

Verified: image builds, container serves the UI, licence gate + tabs + dynamic NASA/CDS credential forms work, .netrc written with 0600, and `from polymer.main import run_atm_corr` imports cleanly inside the container.